### PR TITLE
Fix "Use `is` or `is not` to compare with `None`" issue

### DIFF
--- a/src/codeschool/vendor/wagtailmarkdown/mdx/linker/__init__.py
+++ b/src/codeschool/vendor/wagtailmarkdown/mdx/linker/__init__.py
@@ -24,11 +24,11 @@ class LinkerPattern(markdown.inlinepatterns.Pattern):
     def handleMatch(self, m):
         linktypes = self.linktypes
         opts = []
-        if m.group(3) != None and len(m.group(4)):
+        if m.group(3) is not None and len(m.group(4)):
             opts = m.group(4).split('|')[1:]
 
         type = m.group(2)
-        if type == None:
+        if type is None:
             type = '__default__'
         mod = import_module(linktypes[type])
         c = mod.Linker()


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Use `is` or `is not` to compare with `None`](https://www.quantifiedcode.com/app/issue_class/3IY8CZ0v)
Issue details: [https://www.quantifiedcode.com/app/project/gh:cslms:cs-server?groups=code_patterns/%3A3IY8CZ0v](https://www.quantifiedcode.com/app/project/gh:cslms:cs-server?groups=code_patterns/%3A3IY8CZ0v)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)